### PR TITLE
Removing dupe user income configuration

### DIFF
--- a/docs/user_configuration_file.md
+++ b/docs/user_configuration_file.md
@@ -14,11 +14,6 @@ BankProcessingTimeInDays
       Type: Integer
       Context: Related to "get_internal_transfer_references", it restricts the time window considered by the internal transfer cleaning algorithm.
 
-IncomeReferences
-    - Description: These are strings present in transactions references representing actual income.
-      Type: List of Strings
-      Context: Not all positive transactions are considered income, they can also be total or partial refunds. In order to avoid skewing income and expense numbers, positive transactions not matching strings configured in "IncomeReferences" are summed together with "expenses". In this way any refund, which is one case of a positive value not matching "IncomeReferences", automatically subtracts from "expenses".
-
 ExpenseTransactionCodes
     - Description: A list of transaction codes that absolutely identify an expense, for example "CARD_PAYMENT". This is an optional configuration
       Type: List of Strings, optional
@@ -33,21 +28,21 @@ FilterReferenceWordsForGrouping
 ExpenseCategoryDefinition
     - Description: A list of expense category names with their respective tags and references.
       Type: A list of objects as follows,
-          - categoryName: "restaurant"  # simple string
-            categoryTags: # list of strings
+          - CategoryName: "restaurant"  # simple string
+            CategoryTags: # list of strings
                 - "#pub"
                 - "#coffee"
-            categoryReferences: # list of strings
+            CategoryReferences: # list of strings
                 - "mcdonalds"
-    - Context: Expenses are categorized primarily using "categoryTags" that appear in transaction references. Tags are intended to be manually inserted by the using through bank applications. Since that's time consuming, the fallback categorizer searches the full transaction reference for other strings like "macdonalds".
+    - Context: Expenses are categorized primarily using "CategoryTags" that appear in transaction references. Tags are intended to be manually inserted by the using through bank applications. Since that's time consuming, the fallback categorizer searches the full transaction reference for other strings like "macdonalds".
 
 IncomeCategoryDefinition
-    - Description: A list of income category names with their respective tags and references.
+    - Description: A list of income category names with their respective tags and references. The "CategoryReferences" field is used to distinguish income transaction type from expense transaction type.
       Type: A list of objects as follows,
-          - categoryName: "husband-income"  # simple string
-            categoryTags: # list of strings
+          - CategoryName: "husband-income"  # simple string
+            CategoryTags: # list of strings
                 - "#husband-income"
-            categoryReferences: # list of strings
+            CategoryReferences: # list of strings
                 - "husband's company"
-      Context: Incomes are categorized primarily using "categoryTags" that appear in transaction references. Tags are intended to be manually inserted by the using through bank applications. Since that's time consuming, the fallback categorizer searches the full transaction reference for other strings like "husband's company".
+      Context: Incomes are categorized primarily using "CategoryTags" that appear in transaction references. Tags are intended to be manually inserted by the using through bank applications. Since that's time consuming, the fallback categorizer searches the full transaction reference for other strings like "husband's company". Note that not all positive transactions are considered income, they can also be total or partial refunds. In order to avoid skewing income and expense numbers, positive transactions not matching strings configured in "CategoryReferences" for "IncomeCategoryDefinition" are summed together with "expenses". In this way any refund, which is one case of a positive value not matching "CategoryReferences" for "IncomeCategoryDefinition", automatically subtracts from "expenses".
 ```

--- a/personal_finances/config.py
+++ b/personal_finances/config.py
@@ -37,7 +37,6 @@ class UserConfiguration(BaseModel):
     # Required Attributes
     InternalTransferReferences: List[str]
     BankProcessingTimeInDays: int
-    IncomeReferences: List[str]
     FilterReferenceWordsForGrouping: List[str]
     ExpenseCategoryDefinition: List[CategoryDefinition]
     IncomeCategoryDefinition: List[CategoryDefinition]

--- a/personal_finances/transaction/type.py
+++ b/personal_finances/transaction/type.py
@@ -19,9 +19,14 @@ def get_transaction_type(transaction: SimpleTransaction) -> TransactionType:
 
 
 def is_income(transaction: SimpleTransaction) -> bool:
+    income_references = (
+        income_reference
+        for income_category in get_user_configuration().IncomeCategoryDefinition
+        for income_reference in income_category.CategoryReferences
+    )
     return transaction["amount"] > 0 and any(
         income_reference in transaction["referenceText"]
-        for income_reference in get_user_configuration().IncomeReferences
+        for income_reference in income_references
     )
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,7 +22,6 @@ def _drop_dict_keys(
 CORRECT_USER_CONFIG_FULL_DICT: Dict[str, Any] = {
     "InternalTransferReferences": ["mock", "internal"],
     "BankProcessingTimeInDays": 2,
-    "IncomeReferences": ["mocked", "income", "refs"],
     "ExpenseTransactionCodes": ["test", "transaction_code"],
     "FilterReferenceWordsForGrouping": ["non-sense", "characters"],
     "ExpenseCategoryDefinition": [
@@ -53,10 +52,6 @@ CORRECT_USER_CONFIG_FULL_DICT: Dict[str, Any] = {
 
 CORRECT_USER_CONFIG_MISSING_EXPENSE_TRANS_CODE = _drop_dict_keys(
     copy.deepcopy(CORRECT_USER_CONFIG_FULL_DICT), ["ExpenseTransactionCodes"]
-)
-
-MISSING_INCOME_REFERENCES: Dict[str, Any] = _drop_dict_keys(
-    copy.deepcopy(CORRECT_USER_CONFIG_FULL_DICT), ["IncomeReferences"]
 )
 
 MISSING_EXPENSE_CATEGORY_DEFINITION: Dict[str, Any] = _drop_dict_keys(
@@ -115,11 +110,6 @@ def _yamlify_first_element(list_of_user: List[Tuple]) -> List[Tuple]:
                     CORRECT_USER_CONFIG_MISSING_EXPENSE_TRANS_CODE,
                     UserConfiguration(**CORRECT_USER_CONFIG_MISSING_EXPENSE_TRANS_CODE),
                     None,
-                ),
-                (
-                    MISSING_INCOME_REFERENCES,
-                    None,
-                    UserConfigurationParseError,
                 ),
                 (
                     MISSING_EXPENSE_CATEGORY_DEFINITION,


### PR DESCRIPTION
Following up on previous PR #14 , I noticed there was a direct dupe configuration for income references, this PR removes it to clean this up.

Related to #3 