### PR TITLE
Add unit test for the cleaning module

### DIFF
--- a/personal_finances/transaction/cleaning.py
+++ b/personal_finances/transaction/cleaning.py
@@ -1,6 +1,5 @@
-from typing import List, Tuple
+from typing import List
 from datetime import timedelta
-from itertools import chain
 from .definition import SimpleTransaction
 from ..config import get_user_configuration
 import logging
@@ -18,27 +17,27 @@ def _has_internal_transfer_features(transaction: SimpleTransaction) -> bool:
 
 def _get_internal_transfers(
     transactions: List[SimpleTransaction],
-) -> List[Tuple[str, str]]:
-    skip_processing = set()
-    internal_transfers = list()
-    internal_transfer_ids = list()
-    for current_transaction in transactions:
-        current_id = current_transaction["transactionId"]
-        current_amount = current_transaction["amount"]
-        current_datetime = current_transaction["datetime"]
+) -> set[int]:
+    internal_transfers = set()
+    for index, current_transaction in enumerate(transactions):
+        
 
-        if current_id in skip_processing or not _has_internal_transfer_features(
+        current_datetime = current_transaction["datetime"]
+        current_amount = current_transaction["amount"]
+
+        if index in internal_transfers or not _has_internal_transfer_features(
             current_transaction
         ):
             continue
 
         matching_transactions = [
             transaction
-            for transaction in transactions
+            for index, transaction in enumerate(transactions)
             if _has_internal_transfer_features(transaction)
             and current_amount == -transaction["amount"]
             and abs(current_datetime - transaction["datetime"])
             < timedelta(days=get_user_configuration().BankProcessingTimeInDays)
+            and index not in internal_transfers
         ]
 
         if len(matching_transactions) > 1:
@@ -53,28 +52,24 @@ def _get_internal_transfers(
         if len(matching_transactions) == 0:
             continue
 
-        internal_transfers.append((current_transaction, matching_transactions[0]))
-        internal_transfer_ids.append(
-            (current_id, matching_transactions[0]["transactionId"])
-        )
-        skip_processing.add(current_id)
-        skip_processing.add(matching_transactions[0]["transactionId"])
+        internal_transfers.add(transactions.index(current_transaction))
+        internal_transfers.add(transactions.index(matching_transactions[0]))
+
         LOGGER.info(
             f"""
             internal transfer pair detected
             {current_transaction} {matching_transactions[0]}
             """
         )
-
-    return internal_transfer_ids
+    return internal_transfers
 
 
 def remove_internal_transfers(
     transactions: List[SimpleTransaction],
 ) -> List[SimpleTransaction]:
-    internal_transfer_ids = set(chain(*_get_internal_transfers(transactions)))
+    internal_transfer_ids = _get_internal_transfers(transactions)
     return [
         transaction
-        for transaction in transactions
-        if transaction["transactionId"] not in internal_transfer_ids
+        for index, transaction in enumerate(transactions)
+        if index not in internal_transfer_ids
     ]

--- a/personal_finances/transaction/cleaning.py
+++ b/personal_finances/transaction/cleaning.py
@@ -8,6 +8,17 @@ import logging
 LOGGER = logging.getLogger(__name__)
 
 
+def _validate_transaction(transaction: SimpleTransaction) -> None:
+    for key, expected_type in SimpleTransaction.__annotations__.items():
+        value = transaction.get(key, None)
+        if key == "amount" and (isinstance(value, float) or isinstance(value, int)):
+            continue  # Allow integers for 'amount' as well as floats
+        if not isinstance(value, expected_type):
+            raise TypeError(
+                f"Invalid type for {key}, expected {expected_type.__name__}"
+            )
+
+
 def _has_internal_transfer_features(transaction: SimpleTransaction) -> bool:
     return transaction["amount"] != 0 and any(
         transfer_ref in transaction["referenceText"]
@@ -20,7 +31,7 @@ def _get_internal_transfers(
 ) -> set[int]:
     internal_transfers = set()
     for index, current_transaction in enumerate(transactions):
-        
+        _validate_transaction(current_transaction)
 
         current_datetime = current_transaction["datetime"]
         current_amount = current_transaction["amount"]

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,9 +1,13 @@
 from unittest.mock import Mock, patch
-import pytest
-from typing import List, Generator
+from typing import List, Generator, Optional, Union
 from personal_finances.transaction.cleaning import remove_internal_transfers
-from personal_finances.transaction.definition import SimpleTransaction
+from personal_finances.transaction.definition import (
+    SimpleTransaction,
+    simple_transaction_builder,
+)
 from datetime import datetime, timedelta
+import random
+import pytest
 from copy import deepcopy
 
 BANK_PROCESSING_TIME_IN_DAYS = 5
@@ -13,7 +17,7 @@ INTERNAL_TRANSFER_REFERENCES = [
     "internal reference 1",
 ]
 
-NO_INTERNAL_TRANSFER_LIST = [
+REGULAR_TRANSACTIONS_LIST = [
     SimpleTransaction(
         transactionId="transaction_dummy_1",
         datetime=datetime.now(),
@@ -30,63 +34,6 @@ NO_INTERNAL_TRANSFER_LIST = [
     ),
 ]
 
-INTERNAL_TRANSFER_LIST = [
-    SimpleTransaction(
-        transactionId="transaction_internal_transfer_1",
-        datetime=datetime.now(),
-        amount=0.3,
-        referenceText="dummy noise"
-        + INTERNAL_TRANSFER_REFERENCES[0]
-        + "data dummy data dummy",
-        bankTransactionCode="dummy_transaction_code",
-    ),
-    SimpleTransaction(
-        transactionId="transaction_internal_transfer_2",
-        datetime=datetime.now(),
-        amount=-0.3,
-        referenceText="dummy noise"
-        + INTERNAL_TRANSFER_REFERENCES[0]
-        + "data dummy data dummy",
-        bankTransactionCode="dummy_transaction_code",
-    ),
-    SimpleTransaction(
-        transactionId="transaction_internal_transfer_3",
-        datetime=datetime.now(),
-        amount=98321.12798,
-        referenceText="dummy noise dummy noise"
-        + INTERNAL_TRANSFER_REFERENCES[1]
-        + "data dummy data dummy",
-        bankTransactionCode="dummy_transaction_code",
-    ),
-    SimpleTransaction(
-        transactionId="transaction_internal_transfer_4",
-        datetime=datetime.now(),
-        amount=-98321.12798,
-        referenceText="dummy dummy dummy test noise"
-        + INTERNAL_TRANSFER_REFERENCES[1]
-        + "data dummy data dummy",
-        bankTransactionCode="dummy_transaction_code",
-    ),
-    SimpleTransaction(
-        transactionId="transaction_internal_transfer_5",
-        datetime=datetime.now(),
-        amount=10,
-        referenceText="dummy noise"
-        + INTERNAL_TRANSFER_REFERENCES[0]
-        + "data dummy data dummy",
-        bankTransactionCode="dummy_transaction_code",
-    ),
-    SimpleTransaction(
-        transactionId="transaction_internal_transfer_6",
-        datetime=datetime.now(),
-        amount=-10,
-        referenceText="dummy dummy dummy test noise"
-        + INTERNAL_TRANSFER_REFERENCES[1]
-        + "data dummy data dummy",
-        bankTransactionCode="dummy_transaction_code",
-    ),
-]
-
 
 @pytest.fixture(autouse=True)
 def user_config_mock() -> Generator[Mock, None, None]:
@@ -98,6 +45,55 @@ def user_config_mock() -> Generator[Mock, None, None]:
         yield u_mock
 
 
+def create_pair_internal_transaction(
+    amount: Optional[float] = None,
+) -> List[SimpleTransaction]:
+    transfer_amount = random.random() if amount is None else amount
+    transfer_datetime = datetime.now()
+
+    internal_trasaction_pair = [
+        simple_transaction_builder(
+            transactionId=str(random.random()),
+            datetime=transfer_datetime,
+            amount=transfer_amount,
+            referenceText="dummy noise"
+            + INTERNAL_TRANSFER_REFERENCES[0]
+            + "data dummy data dummy",
+            bankTransactionCode="dummy_transaction_code",
+        ),
+        simple_transaction_builder(
+            transactionId=str(random.random()),
+            datetime=transfer_datetime,
+            amount=-transfer_amount,
+            referenceText="dummy noise"
+            + INTERNAL_TRANSFER_REFERENCES[1]
+            + "data dummy data dummy",
+            bankTransactionCode="dummy_transaction_code",
+        ),
+    ]
+    return internal_trasaction_pair
+
+
+def create_list_with_internal_transactions(
+    amount: Optional[float] = None,
+) -> List[SimpleTransaction]:
+    return (
+        create_pair_internal_transaction(amount)
+        + create_pair_internal_transaction(amount)
+        + create_pair_internal_transaction(amount)
+    )
+
+
+def copy_first_element(
+    internal_transfer_pair: List[SimpleTransaction],
+) -> List[SimpleTransaction]:
+
+    duplicated_transfer_element = deepcopy(internal_transfer_pair[0])
+    duplicated_transfer_element["transactionId"] = str(random.random())
+
+    return duplicated_transfer_element
+
+
 def assert_transaction_list(
     input_transaction_list: List[SimpleTransaction],
     expected_cleaned_list: List[SimpleTransaction],
@@ -106,55 +102,99 @@ def assert_transaction_list(
 
 
 def test_list_without_internal_transfer_should_get_untouched() -> None:
-    assert_transaction_list(NO_INTERNAL_TRANSFER_LIST, NO_INTERNAL_TRANSFER_LIST)
+    """
+    Validates that a list of transactions without internal transfers
+    remains unchanged after processing.
+    """
+    assert_transaction_list(REGULAR_TRANSACTIONS_LIST, REGULAR_TRANSACTIONS_LIST)
 
 
 def test_list_with_internal_transfer_should_get_cleaned() -> None:
-    one_internal_transaction = NO_INTERNAL_TRANSFER_LIST + INTERNAL_TRANSFER_LIST
-    assert_transaction_list(one_internal_transaction, NO_INTERNAL_TRANSFER_LIST)
+    """
+    Tests whether the remove_internal_transfers function correctly identifies
+    and removes internal transfer transactions from a list that includes both
+    regular and internal transfer transactions.
+    """
+    one_internal_transaction = (
+        REGULAR_TRANSACTIONS_LIST + create_list_with_internal_transactions()
+    )
+    assert_transaction_list(one_internal_transaction, REGULAR_TRANSACTIONS_LIST)
 
 
 def test_list_with_internal_transfer_exceed_proccesing_time() -> None:
-    exceed_day_pair = deepcopy(INTERNAL_TRANSFER_LIST[:2])
-    exceed_day_pair[0]["datetime"] += timedelta(days=BANK_PROCESSING_TIME_IN_DAYS + 1)
-
-    transaction_list = (
-        NO_INTERNAL_TRANSFER_LIST + exceed_day_pair + INTERNAL_TRANSFER_LIST[2:]
+    """
+    Checks if the remove_internal_transfers function properly handles
+    internal transfers that exceed the bank processing time. It ensures
+    that transactions are not considered internal transfers if the time
+    difference between them is greater than the bank's processing time limit
+    """
+    transaction_edited_datetime = create_pair_internal_transaction()
+    transaction_edited_datetime[0]["datetime"] += timedelta(
+        days=BANK_PROCESSING_TIME_IN_DAYS + 1
     )
-    expected_list = NO_INTERNAL_TRANSFER_LIST + exceed_day_pair
-    assert_transaction_list(transaction_list, expected_list)
+
+    transaction_list = REGULAR_TRANSACTIONS_LIST + transaction_edited_datetime
+
+    assert_transaction_list(transaction_list, transaction_list)
 
 
 def test_list_with_zero_amount_in_internal_transfer() -> None:
-    zero_amount_pair = deepcopy(INTERNAL_TRANSFER_LIST[:2])
-    zero_amount_pair[0]["amount"] = 0
+    """
+    Verifies that transactions with a zero amount are not treated
+    as internal transfers.
+    """
+    transaction_edited_ammount = create_pair_internal_transaction()
+    transaction_edited_ammount[0]["amount"] = 0
+
+    transaction_list = REGULAR_TRANSACTIONS_LIST + transaction_edited_ammount
+    assert_transaction_list(transaction_list, transaction_list)
+
+
+def test_list_with_duplicated_internal_transfer_one_element() -> None:
+    """
+    Assesses the handling of duplicated transactions in a list that includes
+    internal transfers. It tests whether remove_internal_transfers can correctly
+    identify and process a list with one element of an internal transfer pair duplicated.
+    """
+    pair_internal_transaction = create_pair_internal_transaction()
+    duplicated_element = copy_first_element(pair_internal_transaction)
 
     transaction_list = (
-        NO_INTERNAL_TRANSFER_LIST + zero_amount_pair + INTERNAL_TRANSFER_LIST[2:]
+        REGULAR_TRANSACTIONS_LIST + pair_internal_transaction + [duplicated_element]
     )
-    expected_list = NO_INTERNAL_TRANSFER_LIST + zero_amount_pair
-    assert_transaction_list(transaction_list, expected_list)
-
-
-def test_list_with_duplicated_internal_transfer_() -> None:
-    duplicated_transfer = INTERNAL_TRANSFER_LIST + [INTERNAL_TRANSFER_LIST[0]]
-
-    transaction_list = NO_INTERNAL_TRANSFER_LIST + duplicated_transfer
-    expected_cleaned_list = NO_INTERNAL_TRANSFER_LIST + [INTERNAL_TRANSFER_LIST[0]]
+    expected_cleaned_list = REGULAR_TRANSACTIONS_LIST + [duplicated_element]
 
     assert_transaction_list(transaction_list, expected_cleaned_list)
 
 
-def test_list_with_invalid_internal_transfer() -> None:
-    for key in INTERNAL_TRANSFER_LIST[0].keys():
-        invalid_list = deepcopy(INTERNAL_TRANSFER_LIST)
-        invalid_list[0][key] = None  # type: ignore[literal-required]
-        transaction_list = NO_INTERNAL_TRANSFER_LIST + invalid_list
-        try:
-            remove_internal_transfers(transaction_list)
-        except Exception as e:
-            assert isinstance(e, TypeError)
-        else:
-            pytest.fail(
-                "TypeError was expected but not raised by key '{0}'".format(key)
-            )
+def test_list_with_internal_transfer_with_same_ammount() -> None:
+    """
+    Tests the function's ability to handle multiple internal transfer transactions
+    with the same amount. It verifies that remove_internal_transfers correctly identifies
+    and removes all internal transfer transactions when they have identical amounts.
+    """
+    same_amount_internal_transfers = create_list_with_internal_transactions(amount=3)
+
+    transaction_list = REGULAR_TRANSACTIONS_LIST + same_amount_internal_transfers
+    expected_cleaned_list = REGULAR_TRANSACTIONS_LIST
+
+    assert_transaction_list(transaction_list, expected_cleaned_list)
+
+
+def test_raising_error_at_get_user_config(user_config_mock: Mock) -> None:
+    """
+    Checks the behavior when get_user_configuration raises a exception.
+    It ensures that the exception is propagated and not silently ignored
+    during the execution.
+    """
+    one_internal_transaction = (
+        REGULAR_TRANSACTIONS_LIST + create_list_with_internal_transactions()
+    )
+
+    user_config_mock.side_effect = [KeyError, user_config_mock.return_value]
+    with pytest.raises(KeyError):
+        assert_transaction_list(one_internal_transaction, REGULAR_TRANSACTIONS_LIST)
+
+    user_config_mock.side_effect = [user_config_mock.return_value, OSError]
+    with pytest.raises(OSError):
+        assert_transaction_list(one_internal_transaction, REGULAR_TRANSACTIONS_LIST)

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -101,6 +101,13 @@ def assert_transaction_list(
     assert remove_internal_transfers(input_transaction_list) == expected_cleaned_list
 
 
+def test_empty_list() -> None:
+    """
+    Validates if an empty input list return an empty output list.
+    """
+    assert_transaction_list([], [])
+
+
 def test_list_without_internal_transfer_should_get_untouched() -> None:
     """
     Validates that a list of transactions without internal transfers

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -135,3 +135,13 @@ def test_list_with_zero_amount_in_internal_transfer() -> None:
     expected_list = NO_INTERNAL_TRANSFER_LIST + zero_amount_pair
     assert_transaction_list(transaction_list, expected_list)
 
+
+def test_list_with_duplicated_internal_transfer_() -> None:
+    duplicated_transfer = INTERNAL_TRANSFER_LIST + [INTERNAL_TRANSFER_LIST[0]]
+
+    transaction_list = NO_INTERNAL_TRANSFER_LIST + duplicated_transfer
+    expected_cleaned_list = NO_INTERNAL_TRANSFER_LIST + [INTERNAL_TRANSFER_LIST[0]]
+
+    assert_transaction_list(transaction_list, expected_cleaned_list)
+
+

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,5 +1,5 @@
 from unittest.mock import Mock, patch
-from typing import List, Generator, Optional, Union
+from typing import List, Generator, Optional
 from personal_finances.transaction.cleaning import remove_internal_transfers
 from personal_finances.transaction.definition import (
     SimpleTransaction,
@@ -86,7 +86,7 @@ def create_list_with_internal_transactions(
 
 def copy_first_element(
     internal_transfer_pair: List[SimpleTransaction],
-) -> List[SimpleTransaction]:
+) -> SimpleTransaction:
 
     duplicated_transfer_element = deepcopy(internal_transfer_pair[0])
     duplicated_transfer_element["transactionId"] = str(random.random())
@@ -118,6 +118,7 @@ def test_list_with_internal_transfer_should_get_cleaned() -> None:
     one_internal_transaction = (
         REGULAR_TRANSACTIONS_LIST + create_list_with_internal_transactions()
     )
+
     assert_transaction_list(one_internal_transaction, REGULAR_TRANSACTIONS_LIST)
 
 
@@ -154,7 +155,8 @@ def test_list_with_duplicated_internal_transfer_one_element() -> None:
     """
     Assesses the handling of duplicated transactions in a list that includes
     internal transfers. It tests whether remove_internal_transfers can correctly
-    identify and process a list with one element of an internal transfer pair duplicated.
+    identify and process a list with one element of an internal transfer pair
+    duplicated.
     """
     pair_internal_transaction = create_pair_internal_transaction()
     duplicated_element = copy_first_element(pair_internal_transaction)
@@ -162,6 +164,7 @@ def test_list_with_duplicated_internal_transfer_one_element() -> None:
     transaction_list = (
         REGULAR_TRANSACTIONS_LIST + pair_internal_transaction + [duplicated_element]
     )
+
     expected_cleaned_list = REGULAR_TRANSACTIONS_LIST + [duplicated_element]
 
     assert_transaction_list(transaction_list, expected_cleaned_list)
@@ -169,9 +172,10 @@ def test_list_with_duplicated_internal_transfer_one_element() -> None:
 
 def test_list_with_internal_transfer_with_same_ammount() -> None:
     """
-    Tests the function's ability to handle multiple internal transfer transactions
-    with the same amount. It verifies that remove_internal_transfers correctly identifies
-    and removes all internal transfer transactions when they have identical amounts.
+    Tests the function's ability to handle multiple internal transfer
+    transactions with the same amount. It verifies that remove_internal_transfers
+    correctly identifies and removes all internal transfer transactions when
+    they have identical amounts.
     """
     same_amount_internal_transfers = create_list_with_internal_transactions(amount=3)
 

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,0 +1,234 @@
+from unittest.mock import Mock, patch
+import pytest
+from typing import List, Generator
+from personal_finances.transaction.cleaning import remove_internal_transfers
+from personal_finances.transaction.definition import SimpleTransaction
+from datetime import datetime
+
+
+@pytest.fixture(autouse=True)
+def user_config_mock() -> Generator[Mock, None, None]:
+    with patch(
+        "personal_finances.transaction.cleaning.get_user_configuration"
+    ) as u_mock:
+        u_mock.return_value.InternalTransferReferences = ["internal_reference_1"]
+        u_mock.return_value.BankProcessingTimeInDays = 5
+        yield u_mock
+
+
+@pytest.mark.parametrize(
+    "raw_transactions,clean_transactions",
+    [
+        ([], []),
+        (
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.2,
+                    referenceText="reference_transaction_2",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.2,
+                    referenceText="reference_transaction_2",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+        ),
+        (
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_3",
+                    datetime=datetime(2022, 2, 1),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+        ),
+        (
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_3",
+                    datetime=datetime(2022, 2, 6),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_3",
+                    datetime=datetime(2022, 2, 6),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+        ),
+        (
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_3",
+                    datetime=datetime(2022, 2, 1),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_3",
+                    datetime=datetime(2022, 2, 1),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+        ),
+        (
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_2",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_3",
+                    datetime=datetime(2022, 2, 1),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+                SimpleTransaction(
+                    transactionId="transaction_4",
+                    datetime=datetime(2022, 2, 1),
+                    amount=-0.3,
+                    referenceText="internal_reference_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+            [
+                SimpleTransaction(
+                    transactionId="transaction_1",
+                    datetime=datetime(2022, 2, 1),
+                    amount=0.1,
+                    referenceText="reference_transaction_1",
+                    bankTransactionCode="dummy_transaction_code",
+                ),
+            ],
+        ),
+    ],
+)
+def test_internal_transfers(
+    raw_transactions: List[SimpleTransaction],
+    clean_transactions: List[SimpleTransaction],
+) -> None:
+    assert remove_internal_transfers(raw_transactions) == clean_transactions

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -1,10 +1,7 @@
 from unittest.mock import Mock, patch
 from typing import List, Generator, Optional
 from personal_finances.transaction.cleaning import remove_internal_transfers
-from personal_finances.transaction.definition import (
-    SimpleTransaction,
-    simple_transaction_builder,
-)
+from personal_finances.transaction.definition import SimpleTransaction
 from datetime import datetime, timedelta
 import random
 import pytest
@@ -52,7 +49,7 @@ def create_pair_internal_transaction(
     transfer_datetime = datetime.now()
 
     internal_trasaction_pair = [
-        simple_transaction_builder(
+        SimpleTransaction(
             transactionId=str(random.random()),
             datetime=transfer_datetime,
             amount=transfer_amount,
@@ -61,7 +58,7 @@ def create_pair_internal_transaction(
             + "data dummy data dummy",
             bankTransactionCode="dummy_transaction_code",
         ),
-        simple_transaction_builder(
+        SimpleTransaction(
             transactionId=str(random.random()),
             datetime=transfer_datetime,
             amount=-transfer_amount,

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -145,3 +145,16 @@ def test_list_with_duplicated_internal_transfer_() -> None:
     assert_transaction_list(transaction_list, expected_cleaned_list)
 
 
+def test_list_with_invalid_internal_transfer() -> None:
+    for key in INTERNAL_TRANSFER_LIST[0].keys():
+        invalid_list = deepcopy(INTERNAL_TRANSFER_LIST)
+        invalid_list[0][key] = None  # type: ignore[literal-required]
+        transaction_list = NO_INTERNAL_TRANSFER_LIST + invalid_list
+        try:
+            remove_internal_transfers(transaction_list)
+        except Exception as e:
+            assert isinstance(e, TypeError)
+        else:
+            pytest.fail(
+                "TypeError was expected but not raised by key '{0}'".format(key)
+            )

--- a/tests/test_cleaning.py
+++ b/tests/test_cleaning.py
@@ -3,7 +3,89 @@ import pytest
 from typing import List, Generator
 from personal_finances.transaction.cleaning import remove_internal_transfers
 from personal_finances.transaction.definition import SimpleTransaction
-from datetime import datetime
+from datetime import datetime, timedelta
+from copy import deepcopy
+
+BANK_PROCESSING_TIME_IN_DAYS = 5
+
+INTERNAL_TRANSFER_REFERENCES = [
+    "internal reference 0",
+    "internal reference 1",
+]
+
+NO_INTERNAL_TRANSFER_LIST = [
+    SimpleTransaction(
+        transactionId="transaction_dummy_1",
+        datetime=datetime.now(),
+        amount=0.1,
+        referenceText="reference_transaction_dummy_1",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+    SimpleTransaction(
+        transactionId="transaction_dummy_2",
+        datetime=datetime.now(),
+        amount=0.2,
+        referenceText="reference_transaction_dummy_2",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+]
+
+INTERNAL_TRANSFER_LIST = [
+    SimpleTransaction(
+        transactionId="transaction_internal_transfer_1",
+        datetime=datetime.now(),
+        amount=0.3,
+        referenceText="dummy noise"
+        + INTERNAL_TRANSFER_REFERENCES[0]
+        + "data dummy data dummy",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+    SimpleTransaction(
+        transactionId="transaction_internal_transfer_2",
+        datetime=datetime.now(),
+        amount=-0.3,
+        referenceText="dummy noise"
+        + INTERNAL_TRANSFER_REFERENCES[0]
+        + "data dummy data dummy",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+    SimpleTransaction(
+        transactionId="transaction_internal_transfer_3",
+        datetime=datetime.now(),
+        amount=98321.12798,
+        referenceText="dummy noise dummy noise"
+        + INTERNAL_TRANSFER_REFERENCES[1]
+        + "data dummy data dummy",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+    SimpleTransaction(
+        transactionId="transaction_internal_transfer_4",
+        datetime=datetime.now(),
+        amount=-98321.12798,
+        referenceText="dummy dummy dummy test noise"
+        + INTERNAL_TRANSFER_REFERENCES[1]
+        + "data dummy data dummy",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+    SimpleTransaction(
+        transactionId="transaction_internal_transfer_5",
+        datetime=datetime.now(),
+        amount=10,
+        referenceText="dummy noise"
+        + INTERNAL_TRANSFER_REFERENCES[0]
+        + "data dummy data dummy",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+    SimpleTransaction(
+        transactionId="transaction_internal_transfer_6",
+        datetime=datetime.now(),
+        amount=-10,
+        referenceText="dummy dummy dummy test noise"
+        + INTERNAL_TRANSFER_REFERENCES[1]
+        + "data dummy data dummy",
+        bankTransactionCode="dummy_transaction_code",
+    ),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -11,224 +93,45 @@ def user_config_mock() -> Generator[Mock, None, None]:
     with patch(
         "personal_finances.transaction.cleaning.get_user_configuration"
     ) as u_mock:
-        u_mock.return_value.InternalTransferReferences = ["internal_reference_1"]
-        u_mock.return_value.BankProcessingTimeInDays = 5
+        u_mock.return_value.InternalTransferReferences = INTERNAL_TRANSFER_REFERENCES
+        u_mock.return_value.BankProcessingTimeInDays = BANK_PROCESSING_TIME_IN_DAYS
         yield u_mock
 
 
-@pytest.mark.parametrize(
-    "raw_transactions,clean_transactions",
-    [
-        ([], []),
-        (
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.2,
-                    referenceText="reference_transaction_2",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.2,
-                    referenceText="reference_transaction_2",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-        ),
-        (
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_3",
-                    datetime=datetime(2022, 2, 1),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-        ),
-        (
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_3",
-                    datetime=datetime(2022, 2, 6),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_3",
-                    datetime=datetime(2022, 2, 6),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-        ),
-        (
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_3",
-                    datetime=datetime(2022, 2, 1),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_3",
-                    datetime=datetime(2022, 2, 1),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-        ),
-        (
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_2",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_3",
-                    datetime=datetime(2022, 2, 1),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-                SimpleTransaction(
-                    transactionId="transaction_4",
-                    datetime=datetime(2022, 2, 1),
-                    amount=-0.3,
-                    referenceText="internal_reference_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-            [
-                SimpleTransaction(
-                    transactionId="transaction_1",
-                    datetime=datetime(2022, 2, 1),
-                    amount=0.1,
-                    referenceText="reference_transaction_1",
-                    bankTransactionCode="dummy_transaction_code",
-                ),
-            ],
-        ),
-    ],
-)
-def test_internal_transfers(
-    raw_transactions: List[SimpleTransaction],
-    clean_transactions: List[SimpleTransaction],
+def assert_transaction_list(
+    input_transaction_list: List[SimpleTransaction],
+    expected_cleaned_list: List[SimpleTransaction],
 ) -> None:
-    assert remove_internal_transfers(raw_transactions) == clean_transactions
+    assert remove_internal_transfers(input_transaction_list) == expected_cleaned_list
+
+
+def test_list_without_internal_transfer_should_get_untouched() -> None:
+    assert_transaction_list(NO_INTERNAL_TRANSFER_LIST, NO_INTERNAL_TRANSFER_LIST)
+
+
+def test_list_with_internal_transfer_should_get_cleaned() -> None:
+    one_internal_transaction = NO_INTERNAL_TRANSFER_LIST + INTERNAL_TRANSFER_LIST
+    assert_transaction_list(one_internal_transaction, NO_INTERNAL_TRANSFER_LIST)
+
+
+def test_list_with_internal_transfer_exceed_proccesing_time() -> None:
+    exceed_day_pair = deepcopy(INTERNAL_TRANSFER_LIST[:2])
+    exceed_day_pair[0]["datetime"] += timedelta(days=BANK_PROCESSING_TIME_IN_DAYS + 1)
+
+    transaction_list = (
+        NO_INTERNAL_TRANSFER_LIST + exceed_day_pair + INTERNAL_TRANSFER_LIST[2:]
+    )
+    expected_list = NO_INTERNAL_TRANSFER_LIST + exceed_day_pair
+    assert_transaction_list(transaction_list, expected_list)
+
+
+def test_list_with_zero_amount_in_internal_transfer() -> None:
+    zero_amount_pair = deepcopy(INTERNAL_TRANSFER_LIST[:2])
+    zero_amount_pair[0]["amount"] = 0
+
+    transaction_list = (
+        NO_INTERNAL_TRANSFER_LIST + zero_amount_pair + INTERNAL_TRANSFER_LIST[2:]
+    )
+    expected_list = NO_INTERNAL_TRANSFER_LIST + zero_amount_pair
+    assert_transaction_list(transaction_list, expected_list)
+


### PR DESCRIPTION
Add unit test for the cleaning module with the following test cases:
- Empty entry list. It should return an empty list, too.
- List of transactions without internal references. It should left the list untouched
- A list containing two transactions with the same internal transfer reference. Since they have the same date but opposite amounts, they should be filtered from the return list.
- List containing two transactions with the same internal transfer reference but different dates, more than defined in `BankProcessingTimeInDays`. It should return the same list as the entry. 
- List containing two transactions with the same internal transfer reference but one of them with 0 as the amount value. It should return the same list as the entry. 
- List contains three transactions with the same internal transfer reference, two with the same amount value, and the other one with the opposite amount value. Should return a list with all these internal transfer reference transactions filtered.