### PR TITLE
Bug Fix: Stop waiting for user bank validation already validated

### DIFF
--- a/personal_finances/user/user_auth_exceptions.py
+++ b/personal_finances/user/user_auth_exceptions.py
@@ -90,7 +90,7 @@ _EXCEPTION_TO_HTTP_RESPONSE: Dict[Tuple, Dict] = {
     (UserIdNotInDatabase,): {
         "statusCode": 400,
         "body": "Invalid User",
-        },
+    },
 }
 
 _UNKNOWN_EXCEPTION_RESPONSE: Dict = {

--- a/personal_finances/user/user_persistence.py
+++ b/personal_finances/user/user_persistence.py
@@ -11,7 +11,7 @@ from personal_finances.user.user_auth_exceptions import (
     UserNotFound,
     InvalidIban,
     InvalidDynamoResponse,
-    UserIdNotInDatabase
+    UserIdNotInDatabase,
 )
 from schwifty import IBAN
 from botocore.exceptions import ClientError
@@ -86,7 +86,7 @@ def update_user_iban(userId: str, newIban: str) -> None:
             UpdateExpression="ADD ibanSet :new_iban",
             ExpressionAttributeValues={":new_iban": set([newIban])},
             ConditionExpression="attribute_exists(userId)",
-            ReturnValues="UPDATED_NEW"
+            ReturnValues="UPDATED_NEW",
         )
     except ClientError as e:
         if e.response["Error"]["Code"] == "ConditionalCheckFailedException":

--- a/tests/user/test_user_persistence.py
+++ b/tests/user/test_user_persistence.py
@@ -13,7 +13,7 @@ from personal_finances.user.user_auth_exceptions import (
     UserNotFound,
     InvalidIban,
     InvalidDynamoResponse,
-    UserIdNotInDatabase
+    UserIdNotInDatabase,
 )
 
 
@@ -217,7 +217,7 @@ def test_update_user_iban_edge_cases(
     iban_validation_exception: type[SchwiftyException],
     user_validation_exception: type[Exception],
     mock_dynamodb_table: Mock,
-    mock_iban: Mock
+    mock_iban: Mock,
 ) -> None:
 
     if iban_validation_exception is not None:
@@ -248,5 +248,5 @@ def test_sucessfull_iban_adding(mock_dynamodb_table: Mock) -> None:
         UpdateExpression="ADD ibanSet :new_iban",
         ExpressionAttributeValues={":new_iban": set([newIban])},
         ConditionExpression="attribute_exists(userId)",
-        ReturnValues="UPDATED_NEW"
+        ReturnValues="UPDATED_NEW",
     )


### PR DESCRIPTION
A bug was introduced in one of the refactors earlier on. When handling bank token authorizations, if tokens are stored and are already valid, then there's not need to re-validate.

This PR fixes this bug by not opening browser urls for authorizations, and not waiting for users to authorize in their bank apps.

Changes:
- Capturing the information whether tokens are valid or not.
- Condition url browser open action and validation wait action on not valid/not existing tokens.
- Fix unit tests to assert the correct mock for localhost provider.
- (sorry for noise in this PR) applying `pipenv run format` into the whole code base, some trailing commas in code outside the scope of this CR were left out.